### PR TITLE
Fix file permission issue

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Browser History",
   "Description": "Search your Web Browser history",
   "Author": "Garulf",
-  "Version": "0.2.0",
+  "Version": "0.3.0",
   "Language": "python",
   "Website": "https://github.com/Garulf/browser-history",
   "IcoPath": "./icon.png",

--- a/plugin/browsers.py
+++ b/plugin/browsers.py
@@ -53,10 +53,13 @@ class Base(object):
         temp_path = self._copy_database(database_path)
 
         # Open the database.
-        with sqlite3.connect(temp_path) as connection:
-            cursor = connection.cursor()
-            cursor.execute(f'{query} LIMIT {limit}')
-            return cursor.fetchall()
+        connection = sqlite3.connect(temp_path)
+        
+        cursor = connection.cursor()
+        cursor.execute(f'{query} LIMIT {limit}')
+        recent = cursor.fetchall()
+        connection.close()
+        return recent
 
     def get_history_items(self, results):
         """


### PR DESCRIPTION
#12 Browser history plugin crashes just after the shortcut keys are pressed due to a file permission error.

 The error occurred while trying to delete the temporarily copied **history** file from the _temp_ folder. Fixed by closing the database connection just after the execution of the query.